### PR TITLE
PVADMIN-49862: Fix CVE-2026-1225

### DIFF
--- a/logback-access/pom.xml
+++ b/logback-access/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-parent</artifactId>
-    <version>1.2.13-rx2</version>
+    <version>1.2.13-rx3</version>
   </parent>
 
   <artifactId>logback-access</artifactId>

--- a/logback-classic/pom.xml
+++ b/logback-classic/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-parent</artifactId>
-    <version>1.2.13-rx2</version>
+    <version>1.2.13-rx3</version>
   </parent>
 
   <artifactId>logback-classic</artifactId>

--- a/logback-classic/src/test/input/joran/fauxEncoder.xml
+++ b/logback-classic/src/test/input/joran/fauxEncoder.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration>
+
+<configuration debug="false">
+    <appender name="CON" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.joran.FauxEncoder"/>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="CON"/>
+    </root>
+</configuration>

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/FauxEncoder.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/FauxEncoder.java
@@ -1,0 +1,24 @@
+/**
+ * Logback: the reliable, generic, fast and flexible logging framework.
+ * Copyright (C) 1999-2026, QOS.ch. All rights reserved.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation
+ *
+ *   or (per the licensee's choosing)
+ *
+ * under the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation.
+ */
+package ch.qos.logback.classic.joran;
+
+public class FauxEncoder {
+
+    public static int COUNT = 0;
+
+    public FauxEncoder() {
+        COUNT++;
+    }
+
+}

--- a/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/joran/JoranConfiguratorTest.java
@@ -145,6 +145,15 @@ public class JoranConfiguratorTest {
     }
 
     @Test
+    public void fauxEncoder_CVE_2026_1225() throws JoranException {
+        FauxEncoder.COUNT = 0;
+        configure(ClassicTestConstants.JORAN_INPUT_PREFIX + "fauxEncoder.xml");
+        assertEquals(0, FauxEncoder.COUNT);
+        checker.assertContainsMatch(Status.ERROR,
+                "Could not create component \\[encoder\\] of type \\[ch.qos.logback.classic.joran.FauxEncoder\\]");
+    }
+
+    @Test
     public void contextRename() throws JoranException {
         loggerContext.setName(CoreConstants.DEFAULT_CONTEXT_NAME);
         configure(ClassicTestConstants.JORAN_INPUT_PREFIX + "contextRename.xml");

--- a/logback-core/pom.xml
+++ b/logback-core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-parent</artifactId>
-    <version>1.2.13-rx2</version>
+    <version>1.2.13-rx3</version>
   </parent>
 
   <artifactId>logback-core</artifactId>

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/IADataForComplexProperty.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/IADataForComplexProperty.java
@@ -26,6 +26,7 @@ public class IADataForComplexProperty {
     final AggregationType aggregationType;
     final String complexPropertyName;
     private Object nestedComplexProperty;
+    private Class<?> expectedPropertyType;
     boolean inError;
 
     public IADataForComplexProperty(PropertySetter parentBean, AggregationType aggregationType, String complexPropertyName) {
@@ -48,6 +49,14 @@ public class IADataForComplexProperty {
 
     public void setNestedComplexProperty(Object nestedComplexProperty) {
         this.nestedComplexProperty = nestedComplexProperty;
+    }
+
+    public Class<?> getExpectedPropertyType() {
+        return expectedPropertyType;
+    }
+
+    public void setExpectedPropertyType(Class<?> expectedPropertyType) {
+        this.expectedPropertyType = expectedPropertyType;
     }
 
 }

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/action/NestedComplexPropertyIA.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/action/NestedComplexPropertyIA.java
@@ -76,7 +76,9 @@ public class NestedComplexPropertyIA extends ImplicitAction {
             // we only push action data if NestComponentIA is applicable
         case AS_COMPLEX_PROPERTY_COLLECTION:
         case AS_COMPLEX_PROPERTY:
+            Class<?> expectedPropertyType = parentBean.getTypeForComplexProperty(nestedElementTagName, aggregationType);
             IADataForComplexProperty ad = new IADataForComplexProperty(parentBean, aggregationType, nestedElementTagName);
+            ad.setExpectedPropertyType(expectedPropertyType);
             actionDataStack.push(ad);
 
             return true;
@@ -118,7 +120,9 @@ public class NestedComplexPropertyIA extends ImplicitAction {
                 addInfo("Assuming default type [" + componentClass.getName() + "] for [" + localName + "] property");
             }
 
-            actionData.setNestedComplexProperty(componentClass.newInstance());
+            Class<?> expectedPropertyType = actionData.getExpectedPropertyType();
+            Object instance = OptionHelper.instantiateClassWithSuperclassRestriction(componentClass, expectedPropertyType);
+            actionData.setNestedComplexProperty(instance);
 
             // pass along the repository
             if (actionData.getNestedComplexProperty() instanceof ContextAware) {

--- a/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/joran/util/PropertySetter.java
@@ -377,6 +377,35 @@ public class PropertySetter extends ContextAwareBase {
 
     }
 
+    public Class<?> getTypeForComplexProperty(String nestedElementTagName, AggregationType aggregationType) {
+        Method aMethod = null;
+        switch (aggregationType) {
+        case AS_COMPLEX_PROPERTY:
+            aMethod = findSetterMethod(nestedElementTagName);
+            break;
+        case AS_COMPLEX_PROPERTY_COLLECTION:
+            aMethod = findAdderMethod(nestedElementTagName);
+            break;
+        default:
+            String msg = "Unexpected aggregationType [" + aggregationType + "] for property [" + nestedElementTagName + "].";
+            addError(msg);
+            throw new IllegalStateException(msg);
+        }
+
+        if (aMethod == null) {
+            String msg = "Could not find method for property [" + nestedElementTagName + "].";
+            addError(msg);
+            throw new IllegalStateException(msg);
+        }
+        Class<?>[] paramTypes = aMethod.getParameterTypes();
+        if (paramTypes.length != 1) {
+            String msg = "Expected [" + aMethod.getName() + "] for property [" + nestedElementTagName + "] to have exactly one parameter.";
+            addError(msg);
+            throw new IllegalStateException(msg);
+        }
+        return paramTypes[0];
+    }
+
     public Class<?> getClassNameViaImplicitRules(String name, AggregationType aggregationType, DefaultNestedComponentRegistry registry) {
 
         Class<?> registryResult = registry.findDefaultComponentType(obj.getClass(), name);

--- a/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
+++ b/logback-core/src/main/java/ch/qos/logback/core/util/OptionHelper.java
@@ -14,6 +14,7 @@
 package ch.qos.logback.core.util;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
 import ch.qos.logback.core.Context;
@@ -42,6 +43,18 @@ public class OptionHelper {
     public static Object instantiateByClassName(String className, Class<?> superClass, ClassLoader classLoader) throws IncompatibleClassException,
                     DynamicClassLoadingException {
         return instantiateByClassNameAndParameter(className, superClass, classLoader, null, null);
+    }
+
+    public static Object instantiateClassWithSuperclassRestriction(Class<?> classObj, Class<?> superClass)
+            throws IncompatibleClassException, DynamicClassLoadingException {
+        if (!superClass.isAssignableFrom(classObj)) {
+            throw new IncompatibleClassException(superClass, classObj);
+        }
+        try {
+            return classObj.getConstructor().newInstance();
+        } catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            throw new DynamicClassLoadingException("Failed to instantiate type " + classObj.getName(), e);
+        }
     }
 
     public static Object instantiateByClassNameAndParameter(String className, Class<?> superClass, ClassLoader classLoader, Class<?> type, Object parameter)

--- a/logback-examples/pom.xml
+++ b/logback-examples/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-parent</artifactId>
-    <version>1.2.13-rx2</version>
+    <version>1.2.13-rx3</version>
   </parent>
 
   <artifactId>logback-examples</artifactId>

--- a/logback-site/pom.xml
+++ b/logback-site/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>ch.qos.logback</groupId>
     <artifactId>logback-parent</artifactId>
-    <version>1.2.13-rx2</version>
+    <version>1.2.13-rx3</version>
   </parent>
 
   <artifactId>logback-site</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ch.qos.logback</groupId>
   <artifactId>logback-parent</artifactId>
-  <version>1.2.13-rx2</version>
+  <version>1.2.13-rx3</version>
   <packaging>pom</packaging>
 
   <name>Logback-Parent</name>


### PR DESCRIPTION
## Summary                                                                                                                                                                                  
  - Back-ports the upstream fix for **CVE-2026-1225** (ACE via class instantiation in logback config files) to the 1.2.13 fork.                                                               
  - Bumps the fork version `1.2.13-rx2` → `1.2.13-rx3`.
                                                                                                                                                                                              
  Jira: [PVADMIN-49862](https://rxlogixdev.atlassian.net/browse/PVADMIN-49862) (parent: [PVADMIN-49785](https://rxlogixdev.atlassian.net/browse/PVADMIN-49785))
                                                                                                                                                                                              
  ## CVE details                                                                                                                                                                              
  | | |                                                                                                                                                                                       
  |---|---|                                                                                                                                                                                   
  | Severity | Low (CVSS 4.0 = 1.8) |
  | Affected | `ch.qos.logback:logback-core` `[0.9.20, 1.5.25)` — fork base `1.2.13` is in range |
  | Upstream fixed in | 1.5.25 |
  | References | [Snyk](https://security.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-15062482) · [GHSA](https://github.com/advisories/GHSA-qqpg-mvqg-649v) ·
  [NVD](https://nvd.nist.gov/vuln/detail/CVE-2026-1225) |

  ## Fix-commit clarification
  Snyk (`SNYK-JAVA-CHQOSLOGBACK-15062482`) and GHSA (`GHSA-qqpg-mvqg-649v`) both reference upstream commit `1f97ae18` as the fix. That commit is the unrelated fix for upstream issue #997
  (false warnings on property-substituted `<appender-ref>`s) and contains no class-instantiation logic.

  The actual fix per logback's [1.5.25 release notes](https://logback.qos.ch/news.html#1.5.25) is upstream commit
  [`d28931f3b`](https://github.com/qos-ch/logback/commit/d28931f3b9ede954285cd22d44e029142bba52e6) — *"restrict object creation to expected supertype"*.

  ## What changed
  The 1.5.x fix targets the Model-based architecture (`ImplicitModelHandler`, etc.) which doesn't exist on 1.2.x. Manually ported the same logic into the analogous Action-based code path:

  - `OptionHelper.instantiateClassWithSuperclassRestriction(Class<?>, Class<?>)` — new helper that throws `IncompatibleClassException` if the loaded class is not assignable to the expected
  supertype.
  - `PropertySetter.getTypeForComplexProperty(String, AggregationType)` — new public method to look up the setter/adder parameter type.
  - `IADataForComplexProperty` — new `expectedPropertyType` field with getter/setter.
  - `NestedComplexPropertyIA` — looks up the expected supertype during `isApplicable()` and uses the new restricted instantiation in `begin()` instead of `componentClass.newInstance()`.

  ## Test plan
  - [x] New unit test `JoranConfiguratorTest#fauxEncoder_CVE_2026_1225` mirrors the upstream fauxListener test: a config declaring `<encoder
  class="ch.qos.logback.classic.joran.FauxEncoder"/>` (where `FauxEncoder` is not an `Encoder`) must (a) not instantiate `FauxEncoder` and (b) emit a `Could not create component [encoder] of
   type [...]` error.
  - [x] Full `mvn package` is green on all 6 reactor modules: 533 logback-core tests + 370 logback-classic tests, 0 failures, 0 errors.
  - [x] No regressions in `JoranConfiguratorTest` (29 tests, 2 pre-existing skips).


[PVADMIN-49862]: https://rxlogixdev.atlassian.net/browse/PVADMIN-49862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PVADMIN-49785]: https://rxlogixdev.atlassian.net/browse/PVADMIN-49785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ